### PR TITLE
Add seat management endpoints and locking support

### DIFF
--- a/ticketing-inventory-service/pom.xml
+++ b/ticketing-inventory-service/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -58,10 +58,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.liquibase</groupId>
-			<artifactId>liquibase-core</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.liquibase</groupId>
+                        <artifactId>liquibase-core</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.3.0</version>
+                </dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/config/OpenApiConfig.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/config/OpenApiConfig.java
@@ -1,0 +1,14 @@
+package com.atc.inventory.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI inventoryOpenAPI() {
+        return new OpenAPI().info(new Info().title("Inventory Service API").version("v1"));
+    }
+}

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/controller/InventoryController.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/controller/InventoryController.java
@@ -1,11 +1,55 @@
 package com.atc.inventory.controller;
 
+import com.atc.inventory.dto.SeatActionRequest;
+import com.atc.inventory.dto.SeatDto;
+import com.atc.inventory.dto.SeatLockRequest;
+import com.atc.inventory.mapper.SeatMapper;
+import com.atc.inventory.service.SeatService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/inventory")
 @RequiredArgsConstructor
 public class InventoryController {
+
+    private final SeatService seatService;
+    private final SeatMapper seatMapper;
+
+    @GetMapping("/seats")
+    @Operation(summary = "List seats for an event")
+    public List<SeatDto> listSeats(@RequestParam Long eventId) {
+        return seatService.listSeats(eventId).stream()
+                .map(seatMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/seats/lock")
+    @Operation(summary = "Lock seats with an expiry")
+    public List<SeatDto> lockSeats(@Valid @RequestBody SeatLockRequest request) {
+        return seatService.lockSeats(request).stream()
+                .map(seatMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/seats/release")
+    @Operation(summary = "Release previously locked seats")
+    public List<SeatDto> releaseSeats(@Valid @RequestBody SeatActionRequest request) {
+        return seatService.releaseSeats(request).stream()
+                .map(seatMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping("/seats/sell")
+    @Operation(summary = "Mark seats as sold")
+    public List<SeatDto> sellSeats(@Valid @RequestBody SeatActionRequest request) {
+        return seatService.sellSeats(request).stream()
+                .map(seatMapper::toDto)
+                .collect(Collectors.toList());
+    }
 }

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/dto/SeatActionRequest.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/dto/SeatActionRequest.java
@@ -1,0 +1,17 @@
+package com.atc.inventory.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SeatActionRequest {
+    @NotNull
+    private Long eventId;
+
+    @NotEmpty
+    private List<@NotBlank String> seatLabels;
+}

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/dto/SeatLockRequest.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/dto/SeatLockRequest.java
@@ -1,0 +1,26 @@
+package com.atc.inventory.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class SeatLockRequest {
+    @NotNull
+    private Long eventId;
+
+    @NotEmpty
+    private List<@NotBlank String> seatLabels;
+
+    @NotNull
+    @Positive
+    private Long lockDurationSeconds;
+
+    private String bookingRef;
+
+    private Long lockedByUser;
+}

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/mapper/SeatLockMapper.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/mapper/SeatLockMapper.java
@@ -1,4 +1,22 @@
 package com.atc.inventory.mapper;
 
+import com.atc.inventory.dto.SeatLockDto;
+import com.atc.inventory.entity.SeatLock;
+import org.springframework.stereotype.Component;
+
+@Component
 public class SeatLockMapper {
+    public SeatLockDto toDto(SeatLock lock) {
+        if (lock == null) {
+            return null;
+        }
+        return new SeatLockDto(
+                lock.getId(),
+                lock.getEventId(),
+                lock.getSeatLabel(),
+                lock.getLockedUntil(),
+                lock.getBookingRef(),
+                lock.getLockedByUser()
+        );
+    }
 }

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/mapper/SeatMapper.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/mapper/SeatMapper.java
@@ -1,4 +1,21 @@
 package com.atc.inventory.mapper;
 
+import com.atc.inventory.dto.SeatDto;
+import com.atc.inventory.entity.EventSeat;
+import org.springframework.stereotype.Component;
+
+@Component
 public class SeatMapper {
+    public SeatDto toDto(EventSeat seat) {
+        if (seat == null) {
+            return null;
+        }
+        return new SeatDto(
+                seat.getId(),
+                seat.getEventId(),
+                seat.getSeatLabel(),
+                seat.getTierId(),
+                seat.getState()
+        );
+    }
 }

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/repository/SeatRepository.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/repository/SeatRepository.java
@@ -1,0 +1,12 @@
+package com.atc.inventory.repository;
+
+import com.atc.inventory.entity.EventSeat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SeatRepository extends JpaRepository<EventSeat, Long> {
+    List<EventSeat> findByEventId(Long eventId);
+    Optional<EventSeat> findByEventIdAndSeatLabel(Long eventId, String seatLabel);
+}

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/service/SeatService.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/service/SeatService.java
@@ -1,4 +1,78 @@
 package com.atc.inventory.service;
 
+import com.atc.inventory.dto.SeatActionRequest;
+import com.atc.inventory.dto.SeatLockRequest;
+import com.atc.inventory.entity.EventSeat;
+import com.atc.inventory.entity.SeatLock;
+import com.atc.inventory.entity.SeatState;
+import com.atc.inventory.repository.SeatLockRepository;
+import com.atc.inventory.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class SeatService {
+
+    private final SeatRepository seatRepository;
+    private final SeatLockRepository seatLockRepository;
+
+    public List<EventSeat> listSeats(Long eventId) {
+        return seatRepository.findByEventId(eventId);
+    }
+
+    public List<EventSeat> lockSeats(SeatLockRequest request) {
+        OffsetDateTime expiry = OffsetDateTime.now().plusSeconds(request.getLockDurationSeconds());
+        List<EventSeat> updated = new ArrayList<>();
+        for (String label : request.getSeatLabels()) {
+            EventSeat seat = seatRepository.findByEventIdAndSeatLabel(request.getEventId(), label)
+                    .orElseThrow(() -> new IllegalArgumentException("Seat not found"));
+            if (seat.getState() != SeatState.FREE) {
+                throw new IllegalStateException("Seat not available for locking");
+            }
+            seat.setState(SeatState.LOCKED);
+            seatRepository.save(seat);
+
+            SeatLock lock = SeatLock.builder()
+                    .eventId(request.getEventId())
+                    .seatLabel(label)
+                    .lockedUntil(expiry)
+                    .bookingRef(request.getBookingRef())
+                    .lockedByUser(request.getLockedByUser())
+                    .build();
+            seatLockRepository.save(lock);
+            updated.add(seat);
+        }
+        return updated;
+    }
+
+    public List<EventSeat> releaseSeats(SeatActionRequest request) {
+        List<EventSeat> updated = new ArrayList<>();
+        for (String label : request.getSeatLabels()) {
+            EventSeat seat = seatRepository.findByEventIdAndSeatLabel(request.getEventId(), label)
+                    .orElseThrow(() -> new IllegalArgumentException("Seat not found"));
+            seat.setState(SeatState.FREE);
+            seatRepository.save(seat);
+            seatLockRepository.deleteByEventIdAndSeatLabel(request.getEventId(), label);
+            updated.add(seat);
+        }
+        return updated;
+    }
+
+    public List<EventSeat> sellSeats(SeatActionRequest request) {
+        List<EventSeat> updated = new ArrayList<>();
+        for (String label : request.getSeatLabels()) {
+            EventSeat seat = seatRepository.findByEventIdAndSeatLabel(request.getEventId(), label)
+                    .orElseThrow(() -> new IllegalArgumentException("Seat not found"));
+            seat.setState(SeatState.SOLD);
+            seatRepository.save(seat);
+            seatLockRepository.deleteByEventIdAndSeatLabel(request.getEventId(), label);
+            updated.add(seat);
+        }
+        return updated;
+    }
 }


### PR DESCRIPTION
## Summary
- add service methods and repository to list, lock, release, and sell seats
- expose REST endpoints for seat operations and document via OpenAPI
- provide DTO validation, mappers, and OpenAPI configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.atc:ticketing-inventory-service:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.5.4 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_68a069eea2c8832886eab6e90bd8bfdf