### PR TITLE
Remove RestTemplate usage in booking service

### DIFF
--- a/ticketing-booking-service/src/main/java/com/atc/booking/TicketingBookingServiceApplication.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/TicketingBookingServiceApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class TicketingBookingServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(TicketingBookingServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(TicketingBookingServiceApplication.class, args);
+    }
 
 }

--- a/ticketing-booking-service/src/main/java/com/atc/booking/controller/BookingController.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/controller/BookingController.java
@@ -1,0 +1,34 @@
+package com.atc.booking.controller;
+
+import com.atc.booking.dto.BookingDto;
+import com.atc.booking.service.BookingService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/booking")
+@RequiredArgsConstructor
+public class BookingController {
+
+    private final BookingService bookingService;
+
+    @PostMapping
+    @Operation(summary = "Start a booking and lock seats")
+    public BookingDto startBooking(@Valid @RequestBody BookingDto request) {
+        return bookingService.startBooking(request);
+    }
+
+    @PostMapping("/{id}/confirm")
+    @Operation(summary = "Confirm payment and mark seats sold")
+    public BookingDto confirmBooking(@PathVariable Long id) {
+        return bookingService.confirmBooking(id);
+    }
+
+    @PostMapping("/{id}/cancel")
+    @Operation(summary = "Cancel booking and release seats")
+    public BookingDto cancelBooking(@PathVariable Long id) {
+        return bookingService.cancelBooking(id);
+    }
+}

--- a/ticketing-booking-service/src/main/java/com/atc/booking/mapper/BookingMapper.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/mapper/BookingMapper.java
@@ -1,0 +1,72 @@
+package com.atc.booking.mapper;
+
+import com.atc.booking.dto.BookingDto;
+import com.atc.booking.dto.BookingItemDto;
+import com.atc.booking.entity.Booking;
+import com.atc.booking.entity.BookingItem;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class BookingMapper {
+
+    public Booking toEntity(BookingDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        return Booking.builder()
+                .id(dto.getId())
+                .userId(dto.getUserId())
+                .eventId(dto.getEventId())
+                .status(dto.getStatus())
+                .totalAmount(dto.getTotalAmount())
+                .currency(dto.getCurrency())
+                .createdAt(dto.getCreatedAt())
+                .build();
+    }
+
+    public BookingItem toEntity(Booking booking, BookingItemDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        return BookingItem.builder()
+                .booking(booking)
+                .seatLabel(dto.getSeatLabel())
+                .tierId(dto.getTierId())
+                .priceAtBooking(dto.getPriceAtBooking())
+                .build();
+    }
+
+    public BookingDto toDto(Booking booking, List<BookingItem> items) {
+        if (booking == null) {
+            return null;
+        }
+        List<BookingItemDto> itemDtos = items == null ? Collections.emptyList() :
+                items.stream().map(this::toDto).collect(Collectors.toList());
+        return BookingDto.builder()
+                .id(booking.getId())
+                .userId(booking.getUserId())
+                .eventId(booking.getEventId())
+                .status(booking.getStatus())
+                .totalAmount(booking.getTotalAmount())
+                .currency(booking.getCurrency())
+                .createdAt(booking.getCreatedAt())
+                .items(itemDtos)
+                .build();
+    }
+
+    private BookingItemDto toDto(BookingItem item) {
+        if (item == null) {
+            return null;
+        }
+        return BookingItemDto.builder()
+                .id(item.getId())
+                .seatLabel(item.getSeatLabel())
+                .tierId(item.getTierId())
+                .priceAtBooking(item.getPriceAtBooking())
+                .build();
+    }
+}

--- a/ticketing-booking-service/src/main/java/com/atc/booking/repository/BookingItemRepository.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/repository/BookingItemRepository.java
@@ -1,0 +1,10 @@
+package com.atc.booking.repository;
+
+import com.atc.booking.entity.BookingItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookingItemRepository extends JpaRepository<BookingItem, Long> {
+    List<BookingItem> findByBookingId(Long bookingId);
+}

--- a/ticketing-booking-service/src/main/java/com/atc/booking/repository/BookingRepository.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/repository/BookingRepository.java
@@ -1,0 +1,7 @@
+package com.atc.booking.repository;
+
+import com.atc.booking.entity.Booking;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+}

--- a/ticketing-booking-service/src/main/java/com/atc/booking/service/BookingService.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/service/BookingService.java
@@ -1,0 +1,72 @@
+package com.atc.booking.service;
+
+import com.atc.booking.dto.BookingDto;
+import com.atc.booking.entity.Booking;
+import com.atc.booking.entity.BookingItem;
+import com.atc.booking.entity.BookingStatus;
+import com.atc.booking.mapper.BookingMapper;
+import com.atc.booking.repository.BookingItemRepository;
+import com.atc.booking.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+    private final BookingRepository bookingRepository;
+    private final BookingItemRepository bookingItemRepository;
+    private final BookingMapper bookingMapper;
+
+    @Transactional
+    public BookingDto startBooking(BookingDto request) {
+        Booking booking = bookingMapper.toEntity(request);
+        booking.setStatus(BookingStatus.PENDING);
+        BigDecimal total = request.getItems() == null ? BigDecimal.ZERO :
+                request.getItems().stream()
+                        .map(i -> i.getPriceAtBooking() == null ? BigDecimal.ZERO : i.getPriceAtBooking())
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+        booking.setTotalAmount(total);
+        booking = bookingRepository.save(booking);
+
+        List<BookingItem> items = request.getItems() == null ? List.of() : request.getItems().stream()
+                .map(i -> bookingMapper.toEntity(booking, i))
+                .map(bookingItemRepository::save)
+                .collect(Collectors.toList());
+
+        // TODO: invoke inventory service via gRPC to lock seats
+
+        return bookingMapper.toDto(booking, items);
+    }
+
+    @Transactional
+    public BookingDto confirmBooking(Long bookingId) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("Booking not found"));
+        List<BookingItem> items = bookingItemRepository.findByBookingId(booking.getId());
+
+        // TODO: invoke inventory service via gRPC to mark seats as sold
+
+        booking.setStatus(BookingStatus.CONFIRMED);
+        booking = bookingRepository.save(booking);
+        return bookingMapper.toDto(booking, items);
+    }
+
+    @Transactional
+    public BookingDto cancelBooking(Long bookingId) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("Booking not found"));
+        List<BookingItem> items = bookingItemRepository.findByBookingId(booking.getId());
+
+        // TODO: invoke inventory service via gRPC to release locked seats
+
+        booking.setStatus(BookingStatus.CANCELLED);
+        booking = bookingRepository.save(booking);
+        return bookingMapper.toDto(booking, items);
+    }
+}


### PR DESCRIPTION
## Summary
- drop RestTemplate bean from booking service application
- strip RestTemplate calls from BookingService and leave TODOs for future gRPC integration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a078823090832881820a48bde98c51