### PR TITLE
feat: add native query for event search

### DIFF
--- a/ticketing-catalog-service/src/main/java/com/atc/catalog/repository/EventDao.java
+++ b/ticketing-catalog-service/src/main/java/com/atc/catalog/repository/EventDao.java
@@ -4,6 +4,8 @@ import com.atc.catalog.entity.Event;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.OffsetDateTime;
@@ -11,8 +13,19 @@ import java.time.OffsetDateTime;
 @Repository
 public interface EventDao extends JpaRepository<Event, Long> {
 
-    Page<Event> findByStartAtBetweenAndHallVenueCityIgnoreCase(OffsetDateTime from,
-                                                               OffsetDateTime to,
-                                                               String city,
+    @Query(value = "SELECT e.* FROM event e " +
+            "JOIN hall h ON e.hall_id = h.id " +
+            "JOIN venue v ON h.venue_id = v.id " +
+            "WHERE e.start_at BETWEEN :from AND :to " +
+            "AND LOWER(v.city) = LOWER(:city)",
+            countQuery = "SELECT COUNT(*) FROM event e " +
+                    "JOIN hall h ON e.hall_id = h.id " +
+                    "JOIN venue v ON h.venue_id = v.id " +
+                    "WHERE e.start_at BETWEEN :from AND :to " +
+                    "AND LOWER(v.city) = LOWER(:city)",
+            nativeQuery = true)
+    Page<Event> findByStartAtBetweenAndHallVenueCityIgnoreCase(@Param("from") OffsetDateTime from,
+                                                               @Param("to") OffsetDateTime to,
+                                                               @Param("city") String city,
                                                                Pageable pageable);
 }


### PR DESCRIPTION
## Summary
- use native SQL query to fetch events by date range and venue city

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0870a0e8083289d90fb93c02fd8b5