### PR TITLE
fix: add javax.annotation dependency

### DIFF
--- a/ticketing-shared-lib/pom.xml
+++ b/ticketing-shared-lib/pom.xml
@@ -58,6 +58,13 @@
                 <version>1.64.0</version>
             </dependency>
 
+            <!-- javax.annotation.Generated is used in gRPC generated sources -->
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+            </dependency>
+
                 <dependency>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
## Summary
- add javax.annotation-api to resolve missing `Generated` annotation in gRPC sources


------
https://chatgpt.com/codex/tasks/task_e_68a3361bd72083289e10c7b19f3226d4