### PR TITLE
Add seat action RPCs to seat proto

### DIFF
--- a/ticketing-shared-lib/src/main/proto/seat.proto
+++ b/ticketing-shared-lib/src/main/proto/seat.proto
@@ -6,6 +6,8 @@ option java_outer_classname = "SeatServiceProto";
 
 service SeatService {
   rpc LockSeats (SeatLockRequest) returns (SeatLockResponse);
+  rpc ReleaseSeats (SeatActionRequest) returns (SeatLockResponse);
+  rpc SellSeats (SeatActionRequest) returns (SeatLockResponse);
 }
 
 message SeatLockRequest {
@@ -14,6 +16,11 @@ message SeatLockRequest {
   int64 lock_duration_seconds = 3;
   string booking_ref = 4;
   int64 locked_by_user = 5;
+}
+
+message SeatActionRequest {
+  int64 event_id = 1;
+  repeated string seat_labels = 2;
 }
 
 message SeatLockResponse {


### PR DESCRIPTION
## Summary
- add `SeatActionRequest` message for operations involving event and seat selection
- support `ReleaseSeats` and `SellSeats` RPCs returning `SeatLockResponse`

------
https://chatgpt.com/codex/tasks/task_e_68a33b59c0508328a6aa670e0ffde429