### PR TITLE
Invoke gRPC seat actions on booking updates

### DIFF
--- a/ticketing-booking-service/pom.xml
+++ b/ticketing-booking-service/pom.xml
@@ -18,11 +18,27 @@
 	<name>ticketing-booking-service</name>
 	<description>Booking orchestration: create bookings, confirm/cancel</description>
 
-	<properties>
-		<java.version>21</java.version>
-		<maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-		<lombok.version>1.18.38</lombok.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+                <lombok.version>1.18.38</lombok.version>
+                <grpc.version>1.57.2</grpc.version>
+        </properties>
+
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>io.grpc</groupId>
+                                <artifactId>grpc-core</artifactId>
+                                <version>${grpc.version}</version>
+                        </dependency>
+                        <dependency>
+                                <groupId>io.grpc</groupId>
+                                <artifactId>grpc-netty-shaded</artifactId>
+                                <version>${grpc.version}</version>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 
         <dependencies>
                 <!-- Spring Boot starters -->

--- a/ticketing-booking-service/src/main/java/com/atc/booking/service/BookingService.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/service/BookingService.java
@@ -64,7 +64,12 @@ public class BookingService {
                 .orElseThrow(() -> new IllegalArgumentException("Booking not found"));
         List<BookingItem> items = bookingItemRepository.findByBookingId(booking.getId());
 
-        // TODO: invoke inventory service via gRPC to mark seats as sold
+        com.atc.shared.grpc.SeatActionRequest.Builder sellReq = com.atc.shared.grpc.SeatActionRequest.newBuilder()
+                .setEventId(booking.getEventId());
+        for (BookingItem item : items) {
+            sellReq.addSeatLabels(item.getSeatLabel());
+        }
+        seatStub.sellSeats(sellReq.build());
 
         booking.setStatus(BookingStatus.CONFIRMED);
         booking = bookingRepository.save(booking);
@@ -77,7 +82,12 @@ public class BookingService {
                 .orElseThrow(() -> new IllegalArgumentException("Booking not found"));
         List<BookingItem> items = bookingItemRepository.findByBookingId(booking.getId());
 
-        // TODO: invoke inventory service via gRPC to release locked seats
+        com.atc.shared.grpc.SeatActionRequest.Builder releaseReq = com.atc.shared.grpc.SeatActionRequest.newBuilder()
+                .setEventId(booking.getEventId());
+        for (BookingItem item : items) {
+            releaseReq.addSeatLabels(item.getSeatLabel());
+        }
+        seatStub.releaseSeats(releaseReq.build());
 
         booking.setStatus(BookingStatus.CANCELLED);
         booking = bookingRepository.save(booking);

--- a/ticketing-inventory-service/pom.xml
+++ b/ticketing-inventory-service/pom.xml
@@ -18,11 +18,27 @@
 	<name>ticketing-inventory-service</name>
 	<description>Inventory service: seat maps, seat locking, availability</description>
 
-	<properties>
-		<java.version>21</java.version>
-		<maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-		<lombok.version>1.18.38</lombok.version>
-	</properties>
+        <properties>
+                <java.version>21</java.version>
+                <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+                <lombok.version>1.18.38</lombok.version>
+                <grpc.version>1.57.2</grpc.version>
+        </properties>
+
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>io.grpc</groupId>
+                                <artifactId>grpc-core</artifactId>
+                                <version>${grpc.version}</version>
+                        </dependency>
+                        <dependency>
+                                <groupId>io.grpc</groupId>
+                                <artifactId>grpc-netty-shaded</artifactId>
+                                <version>${grpc.version}</version>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
 
 	<dependencies>
 		<dependency>

--- a/ticketing-shared-lib/pom.xml
+++ b/ticketing-shared-lib/pom.xml
@@ -26,9 +26,10 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>21</java.version>
-	</properties>
+          <properties>
+                  <java.version>21</java.version>
+                  <grpc.version>1.57.2</grpc.version>
+          </properties>
         <dependencies>
                 <dependency>
                         <groupId>org.projectlombok</groupId>
@@ -42,21 +43,21 @@
                 </dependency>
 
                 <!-- gRPC generated classes dependencies -->
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-protobuf</artifactId>
-                <version>1.64.0</version>
-            </dependency>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-stub</artifactId>
-                <version>1.64.0</version>
-            </dependency>
-            <dependency>
-                <groupId>io.grpc</groupId>
-                <artifactId>grpc-api</artifactId>
-                <version>1.64.0</version>
-            </dependency>
+              <dependency>
+                  <groupId>io.grpc</groupId>
+                  <artifactId>grpc-protobuf</artifactId>
+                  <version>${grpc.version}</version>
+              </dependency>
+              <dependency>
+                  <groupId>io.grpc</groupId>
+                  <artifactId>grpc-stub</artifactId>
+                  <version>${grpc.version}</version>
+              </dependency>
+              <dependency>
+                  <groupId>io.grpc</groupId>
+                  <artifactId>grpc-api</artifactId>
+                  <version>${grpc.version}</version>
+              </dependency>
 
             <!-- javax.annotation.Generated is used in gRPC generated sources -->
             <dependency>
@@ -88,7 +89,7 @@
                                 <configuration>
                                         <protocArtifact>com.google.protobuf:protoc:3.21.12:exe:${os.detected.classifier}</protocArtifact>
                                         <pluginId>grpc-java</pluginId>
-                                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.56.1:exe:${os.detected.classifier}</pluginArtifact>
+                                        <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                                 </configuration>
                                 <executions>
                                         <execution>


### PR DESCRIPTION
## Summary
- Send `sellSeats` gRPC request when confirming bookings
- Call `releaseSeats` gRPC endpoint on booking cancellation
- Align all modules on gRPC `1.57.2`.


------
https://chatgpt.com/codex/tasks/task_e_68a418a5b494832893c49ca65009384e