### PR TITLE
Specify gRPC server port for inventory service

### DIFF
--- a/ticketing-inventory-service/src/main/resources/application.properties
+++ b/ticketing-inventory-service/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=ticketing-inventory-service
 server.servlet.context-path=/inventory
 server.port=8082
+grpc.server.port=9090
 
 # DB
 spring.datasource.url=jdbc:postgresql://localhost:5432/inventory


### PR DESCRIPTION
## Summary
- ensure inventory service exposes gRPC endpoint on port 9090 for consistent communication


------
https://chatgpt.com/codex/tasks/task_e_68a41ff1b674832884a65cf54b8d6e7a