### PR TITLE
chore: remove unused grpc dependencies

### DIFF
--- a/ticketing-catalog-service/pom.xml
+++ b/ticketing-catalog-service/pom.xml
@@ -96,11 +96,6 @@
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
 
-        <dependency>
-            <groupId>net.devh</groupId>
-            <artifactId>grpc-client-spring-boot-starter</artifactId>
-            <version>2.15.0.RELEASE</version>
-        </dependency>
 
     </dependencies>
 

--- a/ticketing-gateway-service/pom.xml
+++ b/ticketing-gateway-service/pom.xml
@@ -58,11 +58,6 @@
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
 
-        <dependency>
-            <groupId>net.devh</groupId>
-            <artifactId>grpc-client-spring-boot-starter</artifactId>
-            <version>2.15.0.RELEASE</version>
-        </dependency>
         </dependencies>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
## Summary
- remove gRPC client dependency from catalog service
- drop unused gRPC client from gateway service

------
https://chatgpt.com/codex/tasks/task_e_68a421dbc7e483288064af9406258f4f