### PR TITLE
Externalize JWT secret configuration across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ Typical flow:
    ```
 6. **Access via gateway**: `http://localhost:8080/api/...`
 
+## JWT Secret Configuration
+
+All services use a shared HMAC secret to sign and validate JWT tokens. The auth service signs tokens while the gateway and downstream services re-validate them using the same secret.
+
+Configure the secret via the `JWT_SECRET` environment variable or the `jwt.secret` property in each service's `application.properties`. **The value must be identical across all services** to ensure validation succeeds.
+
+### Rotating the secret
+
+1. Provide a new value for `JWT_SECRET` and redeploy all services so they can validate tokens signed with the new secret.
+2. Restart the auth service last to begin issuing tokens with the new secret.
+3. After previously issued tokens expire, remove the old secret value from your configuration.
+
+

--- a/ticketing-auth-service/src/main/java/com/atc/auth/security/JwtService.java
+++ b/ticketing-auth-service/src/main/java/com/atc/auth/security/JwtService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -15,11 +16,13 @@ import java.util.Date;
 @Service
 public class JwtService {
     private SecretKey key;
-    private static final String SECRET = "change-me-please-change-me-please!"; // 32+ chars
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String generateToken(User user) {

--- a/ticketing-auth-service/src/main/resources/application.properties
+++ b/ticketing-auth-service/src/main/resources/application.properties
@@ -2,6 +2,9 @@ spring.application.name=ticketing-auth-service
 server.port=8084
 server.servlet.context-path=/auth
 
+# JWT
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
+
 # Database
 spring.datasource.url=jdbc:postgresql://localhost:5432/auth
 spring.datasource.username=postgres

--- a/ticketing-booking-service/src/main/java/com/atc/booking/security/JwtService.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/security/JwtService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -13,11 +14,13 @@ import java.util.Date;
 @Service
 public class JwtService {
     private SecretKey key;
-    private static final String SECRET = "change-me-please-change-me-please!"; // 32+ chars
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String extractUsername(String token) {

--- a/ticketing-booking-service/src/main/resources/application.properties
+++ b/ticketing-booking-service/src/main/resources/application.properties
@@ -3,6 +3,9 @@ spring.application.name=ticketing-booking-service
 server.servlet.context-path=/booking
 server.port=8083
 
+# JWT
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
+
 # DB
 spring.datasource.url=jdbc:postgresql://localhost:5432/booking
 spring.datasource.username=postgres

--- a/ticketing-gateway-service/src/main/java/com/atc/gateway/security/JwtService.java
+++ b/ticketing-gateway-service/src/main/java/com/atc/gateway/security/JwtService.java
@@ -3,9 +3,11 @@ package com.atc.gateway.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -16,13 +18,20 @@ import java.nio.charset.StandardCharsets;
 @Service
 public class JwtService {
 
+    private SecretKey key;
+
     @Value("${jwt.secret}")
     private String secret;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
 
     public Claims parse(String token) {
         return Jwts
                 .parser()
-                .verifyWith(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
+                .verifyWith(key)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();

--- a/ticketing-gateway-service/src/main/resources/application.properties
+++ b/ticketing-gateway-service/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=ticketing-gateway-service
 server.port=8080
 
 # JWT signing secret used for validating tokens
-jwt.secret=MySuperSecretKeyMySuperSecretKey1234567890
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
 
 # MVC Gateway routes
 

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/security/JwtService.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/security/JwtService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -13,11 +14,13 @@ import java.util.Date;
 @Service
 public class JwtService {
     private SecretKey key;
-    private static final String SECRET = "change-me-please-change-me-please!"; // 32+ chars
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String extractUsername(String token) {

--- a/ticketing-inventory-service/src/main/resources/application.properties
+++ b/ticketing-inventory-service/src/main/resources/application.properties
@@ -3,6 +3,9 @@ server.servlet.context-path=/inventory
 server.port=8082
 grpc.server.port=9090
 
+# JWT
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
+
 # DB
 spring.datasource.url=jdbc:postgresql://localhost:5432/inventory
 spring.datasource.username=postgres


### PR DESCRIPTION
## Summary
- Inject JWT secret via `jwt.secret` property in auth, booking, inventory and gateway `JwtService`
- Add shared `jwt.secret` property placeholder to each service's `application.properties`
- Document shared JWT secret usage and rotation guidance in README
