### PR TITLE
Externalize JWT secret configuration across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,16 @@ Typical flow:
    ```
 6. **Access via gateway**: `http://localhost:8080/api/...`
 
+## JWT Secret Configuration
+
+All services use a shared HMAC secret to sign and validate JWT tokens. The auth service signs tokens while the gateway and downstream services re-validate them using the same secret.
+
+Configure the secret via the `JWT_SECRET` environment variable or the `jwt.secret` property in each service's `application.properties`. **The value must be identical across all services** to ensure validation succeeds.
+
+### Rotating the secret
+
+1. Provide a new value for `JWT_SECRET` and redeploy all services so they can validate tokens signed with the new secret.
+2. Restart the auth service last to begin issuing tokens with the new secret.
+3. After previously issued tokens expire, remove the old secret value from your configuration.
+
+

--- a/ticketing-auth-service/src/main/java/com/atc/auth/security/JwtService.java
+++ b/ticketing-auth-service/src/main/java/com/atc/auth/security/JwtService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -15,11 +16,13 @@ import java.util.Date;
 @Service
 public class JwtService {
     private SecretKey key;
-    private static final String SECRET = "change-me-please-change-me-please!"; // 32+ chars
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String generateToken(User user) {

--- a/ticketing-auth-service/src/main/resources/application.properties
+++ b/ticketing-auth-service/src/main/resources/application.properties
@@ -2,6 +2,9 @@ spring.application.name=ticketing-auth-service
 server.port=8084
 server.servlet.context-path=/auth
 
+# JWT
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
+
 # Database
 spring.datasource.url=jdbc:postgresql://localhost:5432/auth
 spring.datasource.username=postgres

--- a/ticketing-booking-service/src/main/java/com/atc/booking/security/JwtService.java
+++ b/ticketing-booking-service/src/main/java/com/atc/booking/security/JwtService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -13,11 +14,13 @@ import java.util.Date;
 @Service
 public class JwtService {
     private SecretKey key;
-    private static final String SECRET = "change-me-please-change-me-please!"; // 32+ chars
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String extractUsername(String token) {

--- a/ticketing-booking-service/src/main/resources/application.properties
+++ b/ticketing-booking-service/src/main/resources/application.properties
@@ -3,6 +3,9 @@ spring.application.name=ticketing-booking-service
 server.servlet.context-path=/booking
 server.port=8083
 
+# JWT
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
+
 # DB
 spring.datasource.url=jdbc:postgresql://localhost:5432/booking
 spring.datasource.username=postgres

--- a/ticketing-gateway-service/src/main/java/com/atc/gateway/security/JwtService.java
+++ b/ticketing-gateway-service/src/main/java/com/atc/gateway/security/JwtService.java
@@ -3,9 +3,11 @@ package com.atc.gateway.security;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -16,13 +18,20 @@ import java.nio.charset.StandardCharsets;
 @Service
 public class JwtService {
 
+    private SecretKey key;
+
     @Value("${jwt.secret}")
     private String secret;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
 
     public Claims parse(String token) {
         return Jwts
                 .parser()
-                .verifyWith(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
+                .verifyWith(key)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();

--- a/ticketing-gateway-service/src/main/resources/application.properties
+++ b/ticketing-gateway-service/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=ticketing-gateway-service
 server.port=8080
 
 # JWT signing secret used for validating tokens
-jwt.secret=MySuperSecretKeyMySuperSecretKey1234567890
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
 
 # MVC Gateway routes
 

--- a/ticketing-inventory-service/src/main/java/com/atc/inventory/security/JwtService.java
+++ b/ticketing-inventory-service/src/main/java/com/atc/inventory/security/JwtService.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -13,11 +14,13 @@ import java.util.Date;
 @Service
 public class JwtService {
     private SecretKey key;
-    private static final String SECRET = "change-me-please-change-me-please!"; // 32+ chars
+
+    @Value("${jwt.secret}")
+    private String secret;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
     public String extractUsername(String token) {

--- a/ticketing-inventory-service/src/main/resources/application.properties
+++ b/ticketing-inventory-service/src/main/resources/application.properties
@@ -3,6 +3,9 @@ server.servlet.context-path=/inventory
 server.port=8082
 grpc.server.port=9090
 
+# JWT
+jwt.secret=${JWT_SECRET:change-me-please-change-me-please!}
+
 # DB
 spring.datasource.url=jdbc:postgresql://localhost:5432/inventory
 spring.datasource.username=postgres

--- a/ticketing-platform.postman_collection.json
+++ b/ticketing-platform.postman_collection.json
@@ -5,9 +5,58 @@
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
-    { "key": "gateway_base_url", "value": "http://localhost:8080/api", "type": "string" }
+    { "key": "gateway_base_url", "value": "http://localhost:8080/api", "type": "string" },
+    { "key": "jwt_token", "value": "", "type": "string" }
   ],
   "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set(\"jwt_token\", pm.response.json().token);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"user\",\n  \"password\": \"password\"\n}"
+            },
+            "url": {
+              "raw": "{{gateway_base_url}}/auth/login",
+              "host": ["{{gateway_base_url}}"],
+              "path": ["auth","login"]
+            }
+          }
+        },
+        {
+          "name": "Me",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
+            "url": {
+              "raw": "{{gateway_base_url}}/auth/me",
+              "host": ["{{gateway_base_url}}"],
+              "path": ["auth","me"]
+            }
+          }
+        }
+      ]
+    },
     {
       "name": "Catalog",
       "item": [
@@ -15,6 +64,9 @@
           "name": "Get All Events",
           "request": {
             "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/catalog/events",
               "host": ["{{gateway_base_url}}"],
@@ -33,6 +85,9 @@
           "name": "Get Event By Id",
           "request": {
             "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/catalog/events/1",
               "host": ["{{gateway_base_url}}"],
@@ -44,6 +99,9 @@
           "name": "Get Venues",
           "request": {
             "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/catalog/venues",
               "host": ["{{gateway_base_url}}"],
@@ -55,6 +113,9 @@
           "name": "Get Venue Halls",
           "request": {
             "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/catalog/venues/1/halls",
               "host": ["{{gateway_base_url}}"],
@@ -71,6 +132,9 @@
           "name": "List Seats",
           "request": {
             "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/inventory/seats?eventId=1",
               "host": ["{{gateway_base_url}}"],
@@ -83,7 +147,10 @@
           "name": "Lock Seats",
           "request": {
             "method": "POST",
-            "header": [ {"key": "Content-Type", "value": "application/json"} ],
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"eventId\": 1,\n  \"seatLabels\": [\"A1\", \"A2\"],\n  \"lockDurationSeconds\": 300,\n  \"bookingRef\": \"BOOK123\",\n  \"lockedByUser\": 1\n}"
@@ -99,7 +166,10 @@
           "name": "Release Seats",
           "request": {
             "method": "POST",
-            "header": [ {"key": "Content-Type", "value": "application/json"} ],
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"eventId\": 1,\n  \"seatLabels\": [\"A1\", \"A2\"]\n}"
@@ -115,7 +185,10 @@
           "name": "Sell Seats",
           "request": {
             "method": "POST",
-            "header": [ {"key": "Content-Type", "value": "application/json"} ],
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"eventId\": 1,\n  \"seatLabels\": [\"A1\", \"A2\"]\n}"
@@ -136,7 +209,10 @@
           "name": "Start Booking",
           "request": {
             "method": "POST",
-            "header": [ {"key": "Content-Type", "value": "application/json"} ],
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"userId\": 1,\n  \"eventId\": 1,\n  \"currency\": \"USD\",\n  \"items\": [\n    {\n      \"seatLabel\": \"A1\",\n      \"tierId\": 1,\n      \"priceAtBooking\": 100.0\n    }\n  ]\n}"
@@ -152,6 +228,9 @@
           "name": "Confirm Booking",
           "request": {
             "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/booking/1/confirm",
               "host": ["{{gateway_base_url}}"],
@@ -163,6 +242,9 @@
           "name": "Cancel Booking",
           "request": {
             "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{jwt_token}}" }
+            ],
             "url": {
               "raw": "{{gateway_base_url}}/booking/1/cancel",
               "host": ["{{gateway_base_url}}"],


### PR DESCRIPTION
## Summary
- Inject JWT secret via `jwt.secret` property in auth, booking, inventory and gateway `JwtService`
- Add shared `jwt.secret` property placeholder to each service's `application.properties`
- Document shared JWT secret usage and rotation guidance in README
- Add auth login requests and token variable to Postman collection so API calls include `Authorization` headers

## Testing
- ⚠️ `cd ticketing-auth-service && mvn -q test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*
- ⚠️ `cd ticketing-booking-service && mvn -q test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*
- ⚠️ `cd ticketing-inventory-service && mvn -q test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*
- ⚠️ `cd ticketing-gateway-service && mvn -q test` *(failed: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b2e2c6f0832885f430366656dfdf