### PR TITLE
Add Liquibase dependency to auth service

### DIFF
--- a/ticketing-auth-service/pom.xml
+++ b/ticketing-auth-service/pom.xml
@@ -46,7 +46,10 @@
             <version>42.7.3</version>
         </dependency>
         <dependency>
-
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-api</artifactId>
             <version>${jjwt.version}</version>


### PR DESCRIPTION
## Summary
- Ensure Liquibase migrations run during auth service startup by depending on `liquibase-core`

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d889572c83288e0d4c73cefcd517